### PR TITLE
Link publishers to registry

### DIFF
--- a/iati/home/templates/home/home_page.html
+++ b/iati/home/templates/home/home_page.html
@@ -28,7 +28,9 @@
 
                 <div class="stat__body stat__body--center">
                     <h2 class="stat__heading stat__heading--large" id="IATI-Website-Tests_num_iati_organisations">{{ page.organisations|intcomma }}</h2>
-                    <p class="stat__copy">{% trans "IATI publishers that contribute data for decision-making and accountability" %}</p>
+                    <p class="stat__copy">{% trans "IATI publishers that contribute data for decision-making and accountability" %}</p><br />
+
+                    <a class="button" href="https://www.iatiregistry.org/publisher" target="_blank">{% trans "Publishers list" %}</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Links the publishers list on iatistandard.org to the relevant publishers page in iatiregistry.org (following various requests to see the full list of publishers)