### PR TITLE
Fix slug trailing dash

### DIFF
--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -1,4 +1,5 @@
 """Model definitions for the home app."""
+import re
 
 from django.db import models
 from django.apps import apps
@@ -106,6 +107,18 @@ class AbstractBasePage(Page):
         """Meta data for the class."""
 
         abstract = True
+
+    def save(self, *args, **kwargs):
+        """Override of the save function to clean slugs."""
+        if(self.slug_en):
+            self.slug_en = re.sub(r'[^\w\s-]', '', self.slug_en).strip("-").lower()
+        if(self.slug_fr):
+            self.slug_fr = re.sub(r'[^\w\s-]', '', self.slug_fr).strip("-").lower()
+        if(self.slug_es):
+            self.slug_es = re.sub(r'[^\w\s-]', '', self.slug_es).strip("-").lower()
+        if(self.slug_pt):
+            self.slug_pt = re.sub(r'[^\w\s-]', '', self.slug_pt).strip("-").lower()
+        super(AbstractBasePage, self).save()
 
 
 class AbstractContentPage(AbstractBasePage):

--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -108,8 +108,8 @@ class AbstractBasePage(Page):
 
         abstract = True
 
-    def save(self, *args, **kwargs):
-        """Override of the save function to clean slugs."""
+    def clean(self):
+        """Override clean to remove trailing dashes from slugs with whitespaces."""
         if(self.slug_en):
             self.slug_en = re.sub(r'[^\w\s-]', '', self.slug_en).strip("-").lower()
         if(self.slug_fr):
@@ -118,7 +118,7 @@ class AbstractBasePage(Page):
             self.slug_es = re.sub(r'[^\w\s-]', '', self.slug_es).strip("-").lower()
         if(self.slug_pt):
             self.slug_pt = re.sub(r'[^\w\s-]', '', self.slug_pt).strip("-").lower()
-        super(AbstractBasePage, self).save()
+        super(AbstractBasePage, self).clean()
 
 
 class AbstractContentPage(AbstractBasePage):

--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -110,14 +110,12 @@ class AbstractBasePage(Page):
 
     def clean(self):
         """Override clean to remove trailing dashes from slugs with whitespaces."""
-        if hasattr(self, 'slug_en'):
-            self.slug_en = re.sub(r'[^\w\s-]', '', self.slug_en).strip("-").lower()
-        if hasattr(self, 'slug_fr'):
-            self.slug_fr = re.sub(r'[^\w\s-]', '', self.slug_fr).strip("-").lower()
-        if hasattr(self, 'slug_es'):
-            self.slug_es = re.sub(r'[^\w\s-]', '', self.slug_es).strip("-").lower()
-        if hasattr(self, 'slug_pt'):
-            self.slug_pt = re.sub(r'[^\w\s-]', '', self.slug_pt).strip("-").lower()
+        for lang in ['en', 'fr', 'es', 'pt']:
+            slug_field = 'slug_{}'.format(lang)
+            slug = getattr(self, slug_field)
+            if slug:
+                slug_clean = re.sub(r'[^\w\s-]', '', slug).strip("-").lower()
+                setattr(self, slug_field, slug_clean)
         super(AbstractBasePage, self).clean()
 
 

--- a/iati/home/models.py
+++ b/iati/home/models.py
@@ -110,13 +110,13 @@ class AbstractBasePage(Page):
 
     def clean(self):
         """Override clean to remove trailing dashes from slugs with whitespaces."""
-        if(self.slug_en):
+        if hasattr(self, 'slug_en'):
             self.slug_en = re.sub(r'[^\w\s-]', '', self.slug_en).strip("-").lower()
-        if(self.slug_fr):
+        if hasattr(self, 'slug_fr'):
             self.slug_fr = re.sub(r'[^\w\s-]', '', self.slug_fr).strip("-").lower()
-        if(self.slug_es):
+        if hasattr(self, 'slug_es'):
             self.slug_es = re.sub(r'[^\w\s-]', '', self.slug_es).strip("-").lower()
-        if(self.slug_pt):
+        if hasattr(self, 'slug_pt'):
             self.slug_pt = re.sub(r'[^\w\s-]', '', self.slug_pt).strip("-").lower()
         super(AbstractBasePage, self).clean()
 

--- a/iati/tests/management_unit_tests.py
+++ b/iati/tests/management_unit_tests.py
@@ -5,6 +5,7 @@ import responses
 from django.core.management.base import CommandError
 from home.management.commands.updatestatistics import ACTIVITY_URL, ORGANISATION_URL, get_total_num_activities, get_total_num_publishers
 from base_functional_tests import TEST_DATA_DIR
+from home.models import AbstractBasePage
 
 
 @responses.activate
@@ -32,3 +33,11 @@ def test_update_statistics_error():
     responses.add(responses.GET, ORGANISATION_URL, status=500, json={'error': 500})
     with pytest.raises(CommandError):
         get_total_num_publishers()
+
+
+@pytest.mark.django_db
+def test_clean_dashes():
+    """Test to clean trailing and leading dashes from slugs."""
+    page = AbstractBasePage(slug_en="--dashes-")
+    page.clean()
+    assert page.slug_en == "dashes"

--- a/iati/tests/management_unit_tests.py
+++ b/iati/tests/management_unit_tests.py
@@ -6,6 +6,7 @@ from django.core.management.base import CommandError
 from home.management.commands.updatestatistics import ACTIVITY_URL, ORGANISATION_URL, get_total_num_activities, get_total_num_publishers
 from base_functional_tests import TEST_DATA_DIR
 from home.models import AbstractBasePage
+from django.utils.text import slugify
 
 
 @responses.activate
@@ -41,3 +42,12 @@ def test_clean_dashes():
     page = AbstractBasePage(slug_en="--dashes-")
     page.clean()
     assert page.slug_en == "dashes"
+
+
+@pytest.mark.django_db
+def test_clean_whitespaces():
+    """Test to clean trailing and leading dashes and whitespaces from slugs when titles have whitespace."""
+    page = AbstractBasePage(title=" whitespaces ")
+    page.slug_en = slugify(page.title, allow_unicode=True)
+    page.clean()
+    assert page.slug_en == "whitespaces"


### PR DESCRIPTION
Overriding the clean method to strip any leading and trailing dashes on slugs, fixing an issue where trailing dashes were added to the automatically generated slugs if there was a whitespace after the title name