### PR TITLE
Adding fallback for community page

### DIFF
--- a/iati/home/templatetags/iati_tags.py
+++ b/iati/home/templatetags/iati_tags.py
@@ -46,9 +46,15 @@ def default_page_url(context, default_page_name="home"):
         'community': CommunityPage,
     }
 
+    default_page_fallbacks = {
+        'community': settings.COMMUNITY_URL,
+    }
+
     default_page = page_model_names[default_page_name].objects.live().first()
 
     if default_page is None or not hasattr(context, 'request'):
+        if default_page_name in default_page_fallbacks:
+            return default_page_fallbacks[default_page_name]
         return ''
     return default_page.get_url(context['request'])
 

--- a/iati/iati/settings/base.py
+++ b/iati/iati/settings/base.py
@@ -231,6 +231,9 @@ MODELTRANSLATION_PO_FILE = "iati.po"
 
 ZENDESK_REQUEST_URL = 'https://iati.zendesk.com/api/v2/requests.json'
 
+# Community URL
+COMMUNITY_URL = 'https://discuss.iatistandard.org/'
+
 # Social Media
 TWITTER_HANDLE = 'IATI_aid'
 YOUTUBE_CHANNEL_URL = 'https://www.youtube.com/channel/UCAVH1gcgJXElsj8ENC-bDQQ'


### PR DESCRIPTION
Adding to work completed for #329.

- Adds a fallback URL for the Community page. When the site is deployed, the Discuss URL will be linked to from the Community menu item until the new Community page is made live. 

I see this as temporary, but essential!