### PR TITLE
Facebook share button doesn’t work

### DIFF
--- a/iati/iati/settings/dev.py
+++ b/iati/iati/settings/dev.py
@@ -12,6 +12,9 @@ SECRET_KEY = '-sg0o=f6(j3!4u6^86!j@0&l^3clslh-#f@02d2^p_4vy0ma0y'
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ALLOWED_HOSTS = ['*']
+INTERNAL_IPS = (
+    '127.0.0.1',
+)
 
 try:
     from .local import *  # # noqa: F401, F403  # pylint: disable=unused-wildcard-import, wildcard-import

--- a/iati/iati/templates/partials/social-share.html
+++ b/iati/iati/templates/partials/social-share.html
@@ -3,7 +3,7 @@
 {% endblock %}
 <ul class="social-list social-list---inline">
     <li class="social-list__item">
-        <div class="fb-share-button" data-href="{{ request.site.hostname }}{{ page.url }}" data-layout="button" data-size="small">
+        <div class="fb-share-button" data-href="{% if not debug %}{{ request.scheme }}://{% endif %}{{ request.site.hostname }}{{ page.url }}" data-layout="button" data-size="small">
             <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">
                 Share
             </a>


### PR DESCRIPTION
As per #347 , `{{ request.scheme }}` has been added if not in `debug` mode

Having the protocol prepended when we're dev-ing locally doesn't make much of a difference to be completely honest, but decided to do it proper and exclude it anyway