### PR TITLE
Switch date_start for date_end when filtering past events. 

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -46,13 +46,13 @@ class EventIndexPage(DefaultPageHeaderImageMixin, AbstractIndexPage):
         """
         now = timezone.now()
         filter_dict = {}
-        archive_years = EventPage.objects.live().descendant_of(self).filter(date_start__lte=now).dates('date_start', 'year', order='DESC')
+        archive_years = EventPage.objects.live().descendant_of(self).filter(date_end__lte=now).dates('date_end', 'year', order='DESC')
         past = request.GET.get('past') == "1"
         if past:
-            filter_dict["date_start__lte"] = now
+            filter_dict["date_end__lte"] = now
             order_by = ['-date_start']
         else:
-            filter_dict["date_start__gte"] = now
+            filter_dict["date_end__gt"] = now
             order_by = ['-featured_event', 'date_start']
 
         try:

--- a/events/tests/test_events_models.py
+++ b/events/tests/test_events_models.py
@@ -39,7 +39,7 @@ class TestEventPage():
     def test_past_events(self, client, events):
         """Test that past parameter calls past events."""
         response = client.get(events.url, {'past': 1}, follow=True)
-        events_before_now = EventPage.objects.filter(date_start__lte=timezone.now()).values_list('id', flat=True)
+        events_before_now = EventPage.objects.filter(date_end__lte=timezone.now()).values_list('id', flat=True)
         events_in_response = response.context['events'].paginator.object_list.values_list('id', flat=True)
         assert set(events_before_now) == set(events_in_response)
         assert response.context['past'] == 1


### PR DESCRIPTION
Addressing #368 
`get_context` for past events now checks the end date instead of the start date for filters.