### PR TITLE
Correct when an event is marked as past

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -49,10 +49,10 @@ class EventIndexPage(DefaultPageHeaderImageMixin, AbstractIndexPage):
         archive_years = EventPage.objects.live().descendant_of(self).filter(date_end__lte=now).dates('date_end', 'year', order='DESC')
         past = request.GET.get('past') == "1"
         if past:
-            filter_dict["date_end__lte"] = now
+            filter_dict["date_end__lt"] = now  # an event is in the past if it ended "yesterday"
             order_by = ['-date_start']
         else:
-            filter_dict["date_end__gt"] = now
+            filter_dict["date_end__gte"] = now  # an event is current / not in the past if the end date is before and up to today
             order_by = ['-featured_event', 'date_start']
 
         try:

--- a/events/tests/test_events_models.py
+++ b/events/tests/test_events_models.py
@@ -39,7 +39,7 @@ class TestEventPage():
     def test_past_events(self, client, events):
         """Test that past parameter calls past events."""
         response = client.get(events.url, {'past': 1}, follow=True)
-        events_before_now = EventPage.objects.filter(date_end__lte=timezone.now()).values_list('id', flat=True)
+        events_before_now = EventPage.objects.filter(date_end__lt=timezone.now()).values_list('id', flat=True)
         events_in_response = response.context['events'].paginator.object_list.values_list('id', flat=True)
         assert set(events_before_now) == set(events_in_response)
         assert response.context['past'] == 1


### PR DESCRIPTION
Current event: `end_date__lte = now`

Past event: `end_date__gt = now`

An event still running/ending today is a current event; any event that ended days prior to today are past.