### PR TITLE
Small hotfix so that the events won't disappear

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -44,15 +44,15 @@ class EventIndexPage(DefaultPageHeaderImageMixin, AbstractIndexPage):
         Use the functions built into the abstract index page class to dynamically filter the child pages and apply pagination, limiting the results to 3 per page.
 
         """
-        now = timezone.now()
+        final_valid_day_begin = timezone.datetime.combine(timezone.now(), timezone.datetime.min.time())
         filter_dict = {}
-        archive_years = EventPage.objects.live().descendant_of(self).filter(date_end__lte=now).dates('date_end', 'year', order='DESC')
+        archive_years = EventPage.objects.live().descendant_of(self).filter(date_end__lte=final_valid_day_begin).dates('date_end', 'year', order='DESC')
         past = request.GET.get('past') == "1"
         if past:
-            filter_dict["date_end__lte"] = now
+            filter_dict["date_end__lt"] = final_valid_day_begin  # an event is in the past if it ended before today's 00:00am
             order_by = ['-date_start']
         else:
-            filter_dict["date_end__gt"] = now
+            filter_dict["date_end__gte"] = final_valid_day_begin  # an event stays as current/future till end date is prior to today's 11:59pm
             order_by = ['-featured_event', 'date_start']
 
         try:

--- a/events/tests/test_events_models.py
+++ b/events/tests/test_events_models.py
@@ -39,7 +39,8 @@ class TestEventPage():
     def test_past_events(self, client, events):
         """Test that past parameter calls past events."""
         response = client.get(events.url, {'past': 1}, follow=True)
-        events_before_now = EventPage.objects.filter(date_end__lte=timezone.now()).values_list('id', flat=True)
+        today_end_date = timezone.datetime.combine(timezone.now(), timezone.datetime.min.time())
+        events_before_now = EventPage.objects.filter(date_end__lt=today_end_date).values_list('id', flat=True)
         events_in_response = response.context['events'].paginator.object_list.values_list('id', flat=True)
         assert set(events_before_now) == set(events_in_response)
         assert response.context['past'] == 1


### PR DESCRIPTION
Just adds a check to `datetime.min.time()` to make sure we know when an event is in the past (`ends before 00:00am of Today's date`)