### PR TITLE
Remove rogue static reference in case study index template

### DIFF
--- a/about/templates/about/case_study_index_page.html
+++ b/about/templates/about/case_study_index_page.html
@@ -9,11 +9,6 @@
   {% include "home/includes/hero_heading.html" %}
 </div>
 
-
-{% load static %}
-
-<link href="{% static 'css/basic.min.css' %}" rel="stylesheet">
-
 <div class="row">
   <div class="l-sidebar l-sidebar--reverse">
     <aside class="l-sidebar__aside">


### PR DESCRIPTION
A reference to load static and the basic.css file was in the case study index template by mistake, this has been removed.