### PR TITLE
Allow sub-sub tools pages

### DIFF
--- a/tools/models.py
+++ b/tools/models.py
@@ -106,8 +106,8 @@ class ToolSubPage(AbstractToolPage):
 
     template = 'tools/tool_page.html'
 
-    parent_page_types = ['tools.ToolPage']
-    subpage_types = []
+    parent_page_types = ['tools.ToolPage', 'tools.ToolSubPage']
+    subpage_types = ['tools.ToolSubPage']
 
 
 class FeaturedTool(Orderable):


### PR DESCRIPTION
To address https://trello.com/c/D5XrDBjd/114-add-child-pages-to-the-iati-guidance-site