### PR TITLE
Cache image renditions

### DIFF
--- a/iati/settings/base.py
+++ b/iati/settings/base.py
@@ -642,5 +642,9 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'wagtail_cache',
+    },
+    'renditions': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'wagtail_renditions_cache',
     }
 }


### PR DESCRIPTION
With:
3813, 4002, 3772 (avg 3862.3 ms response)
Without:
4768, 4335, 4261 (avg 4454.6 ms response)
Average of 592 ms saved