### PR TITLE
Hotfix | Delete gunicorn logs >10G to avoid running out of disk space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,5 +109,6 @@ EXPOSE 5000
 RUN mkdir -p /var/log/gunicorn
 RUN chmod 644 /var/log/gunicorn
 RUN touch /var/log/gunicorn/gunicorn.log
+COPY delete_large_logs /etc/periodic/15min/delete_large_logs
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
 CMD ["tail", "-n", "+0", "-f", "/var/log/gunicorn/gunicorn.log"]

--- a/delete_large_logs
+++ b/delete_large_logs
@@ -1,0 +1,2 @@
+#!/bin/sh
+find /var/log/gunicorn/ -size +10000000k -type f -delete


### PR DESCRIPTION
PR for develop, the same as is already on master: https://github.com/IATI/IATI-Standard-Website/pull/724