### PR TITLE
Proxy the prometheus port

### DIFF
--- a/config/nginx/website_dev.conf
+++ b/config/nginx/website_dev.conf
@@ -87,3 +87,13 @@ server {
         return 302 https://iatiwebsitedev.blob.core.windows.net/dev-iati-website$1;
     }
 }
+
+
+# Proxy the prometheus port from the destination server
+server {
+    listen 9158;
+
+    location / {
+        proxy_pass http://XX.XX.XX.XX:9157;
+    }
+}

--- a/config/nginx/website_prod.conf
+++ b/config/nginx/website_prod.conf
@@ -87,3 +87,13 @@ server {
         return 302 https://cdn.iatistandard.org/prod-iati-website$1;
     }
 }
+
+
+# Proxy the prometheus port from the destination server
+server {
+    listen 9158;
+
+    location / {
+        proxy_pass http://XX.XX.XX.XX:9157;
+    }
+}


### PR DESCRIPTION
This is so that we have a fixed IP to give to the prometheus server.