### PR TITLE
guidance_and_support: templates: guidance_page.html: wrap the form in a form tag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: '1'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -22,7 +22,7 @@ jobs:
       - name: Pull static images
         run: docker compose -f docker-compose.dev.yml pull
       - id: cache-docker
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/docker-registry
           key: docker-registry-buildkit-${{ hashFiles('Dockerfile') }}
@@ -57,14 +57,14 @@ jobs:
       STAGE: dev
       NAME: iati-website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: cache-docker
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/docker-registry
           key: docker-registry-buildkit-${{ hashFiles('Dockerfile') }}
@@ -291,14 +291,14 @@ jobs:
       STAGE: prod
       NAME: iati-website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - id: cache-docker
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/docker-registry
           key: docker-registry-buildkit-${{ hashFiles('Dockerfile') }}

--- a/guidance_and_support/templates/guidance_and_support/guidance_page.html
+++ b/guidance_and_support/templates/guidance_and_support/guidance_page.html
@@ -78,7 +78,9 @@
 
     <div class="section" id="support">
         <div class="row">
-            {% include 'guidance_and_support/includes/contact_form.html' with fragment_id='#support' form_class='form--2up' %}
+            <form>
+                {% include 'guidance_and_support/includes/contact_form.html' with fragment_id='#support' form_class='form--2up' %}
+            </form>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
After adding the `referrer` hidden field in the [contact form](https://iatistandard.org/en/guidance/get-support/), the `contact form` at the bottom of [how to publish data](https://iatistandard.org/en/guidance/publishing-data/publishing-checklist/) was like this:

<img width="1312" alt="Screenshot 2025-03-05 at 09 54 48" src="https://github.com/user-attachments/assets/cb72b8f4-0aeb-4475-bc3f-a7f12e14dbc8" />

Now it looks like this:

<img width="1302" alt="Screenshot 2025-03-05 at 09 55 03" src="https://github.com/user-attachments/assets/d3e31da7-0252-4d31-91b6-31a12d00f4d6" />

I have also updated `checkout` and `cache` of github's workflow to v3.