### PR TITLE
Move Terms link to footer in line with design system

### DIFF
--- a/iati/templates/scaffold/footer.html
+++ b/iati/templates/scaffold/footer.html
@@ -35,7 +35,7 @@
     </div>
     <div class="footer__meta">
         <div class="row">
-            <p class="footer__legal">{% trans "Copyright IATI" %} {% now "Y" %}. {% trans "All rights reserved" %}</p>
+            <p class="footer__legal">{% trans "Copyright IATI" %} {% now "Y" %}. {% trans "All rights reserved" %} | <a href="https://web-terms.iatistandard.org/{{ request.LANGUAGE_CODE }}/latest/">{% trans "Terms" %}</a> </p>
             <ul class="social-list">
                 <li class="social-list__item social-list__item--twitter"><a href="https://twitter.com/{{ social_twitter_handle }}" rel="noopener noreferrer" target="_blank">{% trans "Twitter" %}</a></li>
                 <li class="social-list__item social-list__item--youtube"><a href="{{ social_youtube_url }}" rel="noopener noreferrer" target="_blank">{% trans "YouTube" %}</a></li>


### PR DESCRIPTION
This is part of the work to migrate all IATI's various terms & conditions to https://web-terms.iatistandard.org/

So far I have:
* set up redirects for https://iatistandard.org/en/privacy-policy/ and https://iatistandard.org/fr/privacy-policy/ (the URLs that the links under Useful Links used to go to, also found across the web estate in footers etc)
* Changed the URLs of the EN and PR privacy pages in Wagtail and replaced their contents with a short message directing people to the new URL

Once this PR is merged and deployed I will remove those pages entirely. 

TIL that Wagtail only redirects if the redirect from: URL isn't an extant page, which makes sense, but was confusing. 

Two details:
* I haven't tested this; the instructions in the README didn't work for me to get this running locally
* I won't be able to deploy this, so will require help with that